### PR TITLE
Add a rudimentary OpenAI client

### DIFF
--- a/lib/http_wrapper.rb
+++ b/lib/http_wrapper.rb
@@ -1,0 +1,7 @@
+require "net/http"
+
+class HttpWrapper
+  def post(url, body, headers)
+    Net::HTTP.post(URI.parse(url), body, headers)
+  end
+end

--- a/lib/json_http_client.rb
+++ b/lib/json_http_client.rb
@@ -1,0 +1,35 @@
+require "http_wrapper"
+require "json"
+require "json_http_request"
+require "output_listener"
+
+class JsonHttpClient
+  def self.null
+    new(StubbedHttp.new)
+  end
+
+  def initialize(http = HttpWrapper.new)
+    @listener = OutputListener.new
+    @http = http
+  end
+
+  def post(url, response_type, headers, body)
+    @listener.emit(JsonHttpRequest.post(url, headers, body))
+    @http.post(url, body.to_json, headers).body
+  end
+
+  def track_requests
+    @listener.tracker
+  end
+
+  class StubbedHttp
+    def post(url, body, headers)
+      StubbedResponse.new
+    end
+  end
+
+  class StubbedResponse
+    def body
+    end
+  end
+end

--- a/lib/json_http_request.rb
+++ b/lib/json_http_request.rb
@@ -1,0 +1,5 @@
+class JsonHttpRequest < Data.define(:http_method, :url, :headers, :body)
+  def self.post(*)
+    new(Net::HTTP::Post, *)
+  end
+end

--- a/lib/open_ai_client.rb
+++ b/lib/open_ai_client.rb
@@ -1,0 +1,31 @@
+require "prompt_body"
+
+class OpenAiClient
+  OPEN_AI_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+
+  def initialize(http_client, api_key)
+    @http_client = http_client
+    @api_key = api_key
+  end
+
+  def prompt(prompt)
+    @http_client.post(
+      OPEN_AI_ENDPOINT,
+      nil,
+      {
+        "Authorization" => "Bearer #{@api_key}",
+        "Content-Type" => "application/json"
+      },
+      PromptBody.new(
+        model: "gpt-3.5-turbo",
+        messages: [
+          PromptBody::Message.new(
+            role: "user",
+            content: prompt
+          )
+        ],
+        temperature: 0.7
+      )
+    )
+  end
+end

--- a/lib/output_listener.rb
+++ b/lib/output_listener.rb
@@ -1,0 +1,19 @@
+require "output_tracker"
+
+class OutputListener
+  def initialize
+    @listeners = []
+  end
+
+  def emit(*)
+    @listeners.each do |tracker|
+      tracker.add(*)
+    end
+  end
+
+  def tracker
+    OutputTracker.new.tap do |tracker|
+      @listeners << tracker
+    end
+  end
+end

--- a/lib/output_tracker.rb
+++ b/lib/output_tracker.rb
@@ -1,0 +1,11 @@
+class OutputTracker
+  attr_reader :output
+
+  def initialize
+    @output = []
+  end
+
+  def add(data)
+    @output << data
+  end
+end

--- a/lib/prompt_body.rb
+++ b/lib/prompt_body.rb
@@ -1,0 +1,11 @@
+class PromptBody < Data.define(:model, :messages, :temperature)
+  def to_json(*)
+    to_h.to_json(*)
+  end
+
+  class Message < Data.define(:role, :content)
+    def to_json(*)
+      to_h.to_json(*)
+    end
+  end
+end

--- a/spec/json_http_client_spec.rb
+++ b/spec/json_http_client_spec.rb
@@ -1,0 +1,48 @@
+require "json_http_client"
+
+RSpec.describe JsonHttpClient do
+  it "tracks requests" do
+    stub_const("ExampleBody", Data.define(:content))
+    json_http_client = JsonHttpClient.null
+    tracker = json_http_client.track_requests
+
+    json_http_client.post(
+      "/post-endpoint",
+      nil,
+      {
+        "TEST_HEADER_KEY_1" => "TEST_HEADER_VALUE_1",
+        "TEST_HEADER_KEY_2" => "TEST_HEADER_VALUE_2"
+      },
+      ExampleBody.new("TEST_POST")
+    )
+
+    expected_response = JsonHttpRequest.post(
+      "/post-endpoint",
+      {
+        "TEST_HEADER_KEY_1" => "TEST_HEADER_VALUE_1",
+        "TEST_HEADER_KEY_2" => "TEST_HEADER_VALUE_2"
+      },
+      ExampleBody.new("TEST_POST")
+    )
+    expect(tracker.output).to contain_exactly(expected_response)
+  end
+
+  context "when nulled" do
+    it "returns nil" do
+      stub_const("ExampleBody", Data.define(:content))
+      json_http_client = JsonHttpClient.null
+
+      response = json_http_client.post(
+        "/post-endpoint",
+        nil,
+        {
+          "TEST_HEADER_KEY_1" => "TEST_HEADER_VALUE_1",
+          "TEST_HEADER_KEY_2" => "TEST_HEADER_VALUE_2"
+        },
+        ExampleBody.new("TEST_POST")
+      )
+
+      expect(response).to be_nil
+    end
+  end
+end

--- a/spec/open_ai_client_spec.rb
+++ b/spec/open_ai_client_spec.rb
@@ -1,0 +1,33 @@
+require "json_http_client"
+require "json_http_request"
+require "open_ai_client"
+require "prompt_body"
+
+RSpec.describe OpenAiClient do
+  it "sends a prompt to Open AI" do
+    http_client = JsonHttpClient.null
+    http_requests = http_client.track_requests
+
+    open_ai = OpenAiClient.new(http_client, "TEST_API_KEY")
+    open_ai.prompt("TEST_PROMPT")
+
+    expected_request = JsonHttpRequest.post(
+      "https://api.openai.com/v1/chat/completions",
+      {
+        "Authorization" => "Bearer TEST_API_KEY",
+        "Content-Type" => "application/json"
+      },
+      PromptBody.new(
+        model: "gpt-3.5-turbo",
+        messages: [
+          PromptBody::Message.new(
+            role: "user",
+            content: "TEST_PROMPT"
+          )
+        ],
+        temperature: 0.7
+      )
+    )
+    expect(http_requests.output).to contain_exactly(expected_request)
+  end
+end

--- a/spec/output_listener_spec.rb
+++ b/spec/output_listener_spec.rb
@@ -1,0 +1,52 @@
+require "output_listener"
+
+RSpec.describe OutputListener do
+  context "when we are yet to track anything" do
+    it "is empty" do
+      output_listener = OutputListener.new
+      tracker = output_listener.tracker
+
+      output = tracker.output
+      expect(output).to be_empty
+    end
+  end
+
+  context "when we track something" do
+    it "contains only that item" do
+      output_listener = OutputListener.new
+      tracker = output_listener.tracker
+
+      output_listener.emit("TEST_DATA")
+
+      output = tracker.output
+      expect(output).to contain_exactly("TEST_DATA")
+    end
+  end
+
+  context "when we track many things" do
+    it "contains only those items" do
+      output_listener = OutputListener.new
+      tracker = output_listener.tracker
+
+      output_listener.emit("TEST_DATA_1")
+      output_listener.emit("TEST_DATA_2")
+
+      output = tracker.output
+      expect(output).to contain_exactly("TEST_DATA_1", "TEST_DATA_2")
+    end
+  end
+
+  context "when we have many trackers" do
+    it "tracks items independent of each other" do
+      output_listener = OutputListener.new
+
+      tracker_1 = output_listener.tracker
+      output_listener.emit("TEST_DATA_1")
+      tracker_2 = output_listener.tracker
+      output_listener.emit("TEST_DATA_2")
+
+      expect(tracker_1.output).to contain_exactly("TEST_DATA_1", "TEST_DATA_2")
+      expect(tracker_2.output).to contain_exactly("TEST_DATA_2")
+    end
+  end
+end


### PR DESCRIPTION
We added a rudimentary OpenAI client. At this point, it does nothing more than send prompts to OpenAI. We even ignore responses to our requests. The tests use a ["Nullable"][] HTTP client as an experiment.

["nullable"]: https://www.jamesshore.com/v2/projects/nullables/testing-without-mocks